### PR TITLE
Feature/set istio host explicitly

### DIFF
--- a/jira-flux-values.yaml
+++ b/jira-flux-values.yaml
@@ -13,7 +13,7 @@ application:
     ingress:
       nginx: false
     proxyName: jira.###ZARF_VAR_DOMAIN###
-    domian: ###ZARF_VAR_DOMAIN###
+    domain: ###ZARF_VAR_DOMAIN###
     istio:
       enabled: true
       jira:

--- a/jira-flux-values.yaml
+++ b/jira-flux-values.yaml
@@ -19,6 +19,8 @@ application:
       jira:
         gateways:
           - istio-system/tenant
+        hosts:
+          - jira.###ZARF_VAR_DOMAIN###
     jira:
       resources:
         container:

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -3,7 +3,7 @@ kind: ZarfPackageConfig
 metadata:
   name: jira
   description: "UDS jira capability deployed via flux"
-  version: "0.0.2"
+  version: "0.0.3"
   architecture: amd64
 
 variables:


### PR DESCRIPTION
Testing a change to the chart values that may be preventing the domain from being set properly at deploy time.

The Jira chart differs from others in that the istio hosts (which are used to configure the virtual service address) are [configured dynamically](https://repo1.dso.mil/big-bang/product/community/jira/-/blob/main/chart/values.yaml?ref_type=heads#L1122-1123).

I believe that may be rendered or interpreted at package time with default values, so that despite setting the ZARF_VAR_DOMAIN variable at deploy time, the virtual service still comes up with the default address.

If that is in fact what is happening, setting the value explicitly may circumvent the issue.